### PR TITLE
corrigir instrução de diretorio raiz no README.md

### DIFF
--- a/modulo1-fundamentos/aula_5/README.md
+++ b/modulo1-fundamentos/aula_5/README.md
@@ -6,7 +6,7 @@ e OSINT de forma segura, pensado para iniciantes da Formação CyberSec.
 ## Estrutura
 
 ```
-recon_lab_novice/
+aula_5/
 ├── docker-compose.yml
 ├── kali/
 │   └── Dockerfile
@@ -29,7 +29,7 @@ recon_lab_novice/
 
 ```bash
 git clone <este‑repo-ou-descompacte-o-zip>
-cd recon_lab_novice
+cd aula_5
 docker compose up -d --build
 ```
 


### PR DESCRIPTION
O nome do diretório raiz não é recon_lab_novice, é aula_5